### PR TITLE
Grammar fix: replaced an infinitive marker with a definite article

### DIFF
--- a/src/content/doc-surrealdb/security/troubleshooting.mdx
+++ b/src/content/doc-surrealdb/security/troubleshooting.mdx
@@ -61,7 +61,7 @@ A specific example for this error is the `AUTHENTICATE`, `SIGNIN` or `SIGNUP` cl
 
 #### Token Expired Error
 
-This error is returned when to token that is being used to authenticate a[session has [expired](/docs/surrealdb/security/authentication#expiration). If this token was issued by SurrealDB, this expiration defaults to an hour and can be changed using the `DURATION FOR TOKEN` clause in [`DEFINE ACCESS`](/docs/surrealql/statements/define/access/record) and [`DEFINE USER`](/docs/surrealql/statements/define/user). If the token was not issued by SurrealDB, this expiration will be set by the `exp` claim. 
+This error is returned when the token that is being used to authenticate a session has [expired](/docs/surrealdb/security/authentication#expiration). If this token was issued by SurrealDB, this expiration defaults to an hour and can be changed using the `DURATION FOR TOKEN` clause in [`DEFINE ACCESS`](/docs/surrealql/statements/define/access/record) and [`DEFINE USER`](/docs/surrealql/statements/define/user). If the token was not issued by SurrealDB, this expiration will be set by the `exp` claim. 
 
 Note that this error will only appear when trying to authenticate the [session](/docs/surrealdb/security/authentication#sessions). After authentication, the session will not expire when the token does, but rather after the independent session duration that has been defined in the `DURATION FOR SESSION` clause. By default, sessions will not expire. When using the HTTP REST API, a persistent session is not established an each request will be individually authenticated, as a consequence, requests made using an expired token will be rejected with this error.
 


### PR DESCRIPTION
- Since the word "token" is not a verb, the "to" that precedes it makes for a grammatical error which can be fixed by using the definite article "the" instead.
- Removed an extra square bracket that precedes a link.